### PR TITLE
Mark commented tests as pending

### DIFF
--- a/spec/instant2fa_spec.rb
+++ b/spec/instant2fa_spec.rb
@@ -7,25 +7,24 @@ describe Instant2fa do
     expect(Instant2fa::VERSION).not_to be nil
   end
 
+  xit "retrives a hosted settings page for a distinct_id" do
+    url = Instant2fa.create_settings(DISTINCT_ID)
+    expect(url).to match(/http:\/\/localhost\:4201\/users\//)
+  end
 
-  # it "retrives a hosted settings page for a distinct_id" do
-  #   url = Instant2fa.create_settings(DISTINCT_ID)
-  #   expect(url).to match(/http:\/\/localhost\:4201\/users\//)
-  # end
+  xit "raises an exception if the user has not enabled mfa" do
+    expect {
+      Instant2fa.create_verification("nomfa")
+    }.to raise_error(Instant2fa::Errors::MFANotEnabled)
+  end
 
-  # it "raises an exception if the user has not enabled mfa" do
-  #   expect {
-  #     Instant2fa.create_verification("nomfa")
-  #   }.to raise_error(Instant2fa::Errors::MFANotEnabled)
-  # end
+  xit "retrives a hosted verification page for a distinct_id" do
+    url = Instant2fa.create_verification(DISTINCT_ID)
+    expect(url).to match(/http:\/\/localhost\:4201\/verification-requests\//)
+  end
 
-  # it "retrives a hosted verification page for a distinct_id" do
-  #   url = Instant2fa.create_verification(DISTINCT_ID)
-  #   expect(url).to match(/http:\/\/localhost\:4201\/verification-requests\//)
-  # end
-
-  # it "confirms a valid verification" do
-  #   result = Instant2fa.confirm_verification(DISTINCT_ID, 'tok_2d4b459bec1f465392310abec379f806')
-  #   expect(result).to be(true)
-  # end
+  xit "confirms a valid verification" do
+    result = Instant2fa.confirm_verification(DISTINCT_ID, 'tok_2d4b459bec1f465392310abec379f806')
+    expect(result).to be(true)
+  end
 end


### PR DESCRIPTION
Commented code is gross! Ideally I'd just write the code for these
tests, but I guess the intent here was to make 'em pass somehow. Marking
them as pending is a nice alternative way to remind us that these tests
are broken (but important to get working!)